### PR TITLE
Select HCs using profile likelihood

### DIFF
--- a/01g_HCs.sh
+++ b/01g_HCs.sh
@@ -254,6 +254,15 @@ ${R_directory}Rscript resources/genetics/generate_hcs.R \
     "${hcs_plot}" \
     "${hcs_scatter_plot}"
 
+echo "Selecting HCs using profile likelihood"
+${R_directory}Rscript resources/genetics/select_hcs_profile_likelihood.R \
+    "${hcs_kernel_prop}" \
+    "${hcs_file}" \
+    "${hcs_profile_selected_file}" \
+    "${hcs_profile_likelihood}" \
+    "${hcs_profile_selection}" \
+    "${hcs_profile_plot}"
+
 echo "Generating side-by-side scatter plots for HC1vHC2, HC2vHC3 and HC1vHC3, coloured by factors (population-structure check)"
 ${R_directory}Rscript resources/genetics/hc_pop_scatter.R \
     "${hcs_file}" \

--- a/01g_HCs.sh
+++ b/01g_HCs.sh
@@ -280,11 +280,11 @@ ${R_directory}Rscript resources/genetics/corr_lm_hc_pc.R \
     ${genetic_outlier_ids} \
     ${section_01_dir}
 
-# generate qcovar file with HCs for gwas
+# Generate qcovar file with profile-likelihood selected HCs for GWAS.
 ${R_directory}Rscript resources/methylation/generate_qcovar_with_hcs.R \
     "${covariates_combined}.txt" \
     "${bfile}.fam" \
-    "${hcs_file}" \
+    "${hcs_profile_selected_file}" \
     "${qcovar_hc_file}" \
     "${scripts_directory}" 
 

--- a/resources/genetics/generate_hcs.R
+++ b/resources/genetics/generate_hcs.R
@@ -20,13 +20,15 @@ sample_id <- data.frame(fam[, .(V1, V2)])
 colnames(sample_id) = c("FID", "IID")
 nind = nrow(sample_id)
 
-if (nind < 100) {
-    number_of_HCs = nind
-    message("Number of individuals less than 100, setting number of HCs to ", nind, "\n")
-    } else {
-    number_of_HCs = 100
-    message("Setting number of HCs to 100\n")
-}
+initial_rank <- if (nind < 100) nind else 100
+rank_candidates <- unique(c(initial_rank, 80, 60, 40, 20))
+rank_candidates <- rank_candidates[rank_candidates <= initial_rank]
+
+message(
+  "SVD rank candidates: ",
+  paste(rank_candidates, collapse = " -> "),
+  "\n"
+)
 
 message("Reading full chunk length data\n")
 # no header in the full length file
@@ -36,7 +38,43 @@ message("Making sparse matrix\n")
 A <- sparseMatrix(df$V1, df$V2, x = log10(df$V3+1), dims=c(nind,nind))
 
 message("Performing svd \n")
-res<-sparsesvd(A,rank=number_of_HCs)
+res <- NULL
+error_messages <- character()
+
+for (candidate_rank in rank_candidates) {
+  message("Attempting SVD with rank ", candidate_rank)
+
+  result <- tryCatch(
+    sparsesvd(A, rank = candidate_rank),
+    error = function(e) {
+      error_messages <<- c(
+        error_messages,
+        paste0("rank ", candidate_rank, ": ", conditionMessage(e))
+      )
+      message(
+        "SVD failed at rank ",
+        candidate_rank,
+        ": ",
+        conditionMessage(e)
+      )
+      NULL
+    }
+  )
+
+  if (!is.null(result)) {
+    res <- result
+    number_of_HCs <- candidate_rank
+    message("SVD succeeded with rank ", number_of_HCs, "\n")
+    break
+  }
+}
+
+if (is.null(res)) {
+  stop(
+    "SVD failed for all attempted ranks:\n",
+    paste(error_messages, collapse = "\n")
+  )
+}
 
 message("Calculating HCs\n")
 HCs <- res$u %*% diag(sqrt(res$d))

--- a/resources/genetics/select_hcs_profile_likelihood.R
+++ b/resources/genetics/select_hcs_profile_likelihood.R
@@ -42,7 +42,6 @@ if (file.exists(selected_hcs_file)) {
 }
 
 required_spectrum_columns <- c("HC", "index", "prop_explained")
-minimum_noise_hcs <- 5L
 
 profile_likelihood <- function(values, analysis, index_offset = 0L) {
   n_values <- length(values)
@@ -169,21 +168,14 @@ fwrite(likelihood_results, likelihood_file)
 primary_selected <- primary[selected == TRUE]
 secondary_selected <- secondary[selected == TRUE]
 final_cutoff <- as.integer(secondary_selected$cutoff_hc)
-selection_status <- if (secondary_selected$n_noise < minimum_noise_hcs) {
-  "review_required"
-} else {
-  "ok"
-}
 
 selection_summary <- data.table(
   n_hcs_available = length(values),
   primary_cutoff = as.integer(primary_selected$cutoff_hc),
   secondary_local_q = as.integer(secondary_selected$local_q),
   final_cutoff = final_cutoff,
-  minimum_noise_hcs = minimum_noise_hcs,
   remaining_noise_hcs = as.integer(secondary_selected$n_noise),
-  input_scale = "raw_prop_explained",
-  status = selection_status
+  input_scale = "raw_prop_explained"
 )
 fwrite(selection_summary, selection_file)
 
@@ -237,45 +229,32 @@ ggsave(
   dpi = 300
 )
 
-if (selection_status == "review_required") {
-  message(
-    "Profile-likelihood cutoff HC",
-    final_cutoff,
-    " leaves only ",
-    secondary_selected$n_noise,
-    " noise HCs; at least ",
-    minimum_noise_hcs,
-    " are required. Selection requires review, so no selected HC file ",
-    "was written."
-  )
-} else {
-  message("Reading complete HC file: ", complete_hcs_file)
-  complete_hcs <- fread(complete_hcs_file)
-  required_hc_columns <- paste0("HC", seq_len(final_cutoff))
-  required_output_columns <- c("FID", "IID", required_hc_columns)
-  missing_hc_columns <- setdiff(required_output_columns, names(complete_hcs))
+message("Reading complete HC file: ", complete_hcs_file)
+complete_hcs <- fread(complete_hcs_file)
+required_hc_columns <- paste0("HC", seq_len(final_cutoff))
+required_output_columns <- c("FID", "IID", required_hc_columns)
+missing_hc_columns <- setdiff(required_output_columns, names(complete_hcs))
 
-  if (length(missing_hc_columns) > 0L) {
-    stop(
-      "Complete HC file is missing required column(s): ",
-      paste(missing_hc_columns, collapse = ", ")
-    )
-  }
-
-  selected_hcs <- complete_hcs[, ..required_output_columns]
-  fwrite(
-    selected_hcs,
-    selected_hcs_file,
-    sep = " ",
-    col.names = TRUE
-  )
-  message(
-    "Selected HC file written with HC1..HC",
-    final_cutoff,
-    ": ",
-    selected_hcs_file
+if (length(missing_hc_columns) > 0L) {
+  stop(
+    "Complete HC file is missing required column(s): ",
+    paste(missing_hc_columns, collapse = ", ")
   )
 }
+
+selected_hcs <- complete_hcs[, ..required_output_columns]
+fwrite(
+  selected_hcs,
+  selected_hcs_file,
+  sep = " ",
+  col.names = TRUE
+)
+message(
+  "Selected HC file written with HC1..HC",
+  final_cutoff,
+  ": ",
+  selected_hcs_file
+)
 
 message("Profile-likelihood results written to: ", likelihood_file)
 message("Profile-likelihood selection written to: ", selection_file)

--- a/resources/genetics/select_hcs_profile_likelihood.R
+++ b/resources/genetics/select_hcs_profile_likelihood.R
@@ -1,0 +1,282 @@
+#!/usr/bin/env Rscript
+
+# Select a cohort-specific HC cutoff using the Zhu-Ghodsi profile-likelihood
+# elbow criterion. The complete HC file is preserved; a separate file
+# containing FID, IID and HC1..HCk is written for later downstream use.
+#
+# Args:
+#   1. HC spectrum CSV (HC, index, prop_explained)
+#   2. Complete HC file (FID IID HC1..HCn)
+#   3. Selected HC output file
+#   4. Per-cutoff profile-likelihood CSV
+#   5. Selection summary CSV
+#   6. Profile-likelihood PNG
+
+suppressPackageStartupMessages({
+  library(data.table)
+  library(ggplot2)
+})
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 6) {
+  stop(
+    "Usage: select_hcs_profile_likelihood.R ",
+    "<spectrum_csv> <complete_hcs_file> <selected_hcs_file> ",
+    "<likelihood_csv> <selection_csv> <plot_png>"
+  )
+}
+
+spectrum_file <- args[1]
+complete_hcs_file <- args[2]
+selected_hcs_file <- args[3]
+likelihood_file <- args[4]
+selection_file <- args[5]
+plot_file <- args[6]
+
+if (normalizePath(complete_hcs_file, mustWork = FALSE) ==
+    normalizePath(selected_hcs_file, mustWork = FALSE)) {
+  stop("The selected HC output must not overwrite the complete HC file")
+}
+if (file.exists(selected_hcs_file)) {
+  file.remove(selected_hcs_file)
+}
+
+required_spectrum_columns <- c("HC", "index", "prop_explained")
+minimum_noise_hcs <- 5L
+
+profile_likelihood <- function(values, analysis, index_offset = 0L) {
+  n_values <- length(values)
+  if (n_values < 3L) {
+    stop(
+      analysis,
+      " profile likelihood requires at least 3 component values; found ",
+      n_values
+    )
+  }
+
+  result <- rbindlist(lapply(seq_len(n_values - 1L), function(q) {
+    signal <- values[seq_len(q)]
+    noise <- values[(q + 1L):n_values]
+    signal_mean <- mean(signal)
+    noise_mean <- mean(noise)
+    signal_sse <- sum((signal - signal_mean)^2)
+    noise_sse <- sum((noise - noise_mean)^2)
+    pooled_variance <- (signal_sse + noise_sse) / (n_values - 2L)
+
+    if (!is.finite(pooled_variance) || pooled_variance <= 0) {
+      log_likelihood <- NA_real_
+    } else {
+      log_likelihood <- sum(
+        dnorm(
+          signal,
+          mean = signal_mean,
+          sd = sqrt(pooled_variance),
+          log = TRUE
+        )
+      ) + sum(
+        dnorm(
+          noise,
+          mean = noise_mean,
+          sd = sqrt(pooled_variance),
+          log = TRUE
+        )
+      )
+    }
+
+    data.table(
+      analysis = analysis,
+      local_q = q,
+      cutoff_hc = q + index_offset,
+      n_signal = length(signal),
+      n_noise = length(noise),
+      signal_mean = signal_mean,
+      noise_mean = noise_mean,
+      signal_sse = signal_sse,
+      noise_sse = noise_sse,
+      pooled_variance = pooled_variance,
+      log_likelihood = log_likelihood
+    )
+  }))
+
+  if (!any(is.finite(result$log_likelihood))) {
+    stop(
+      analysis,
+      " profile likelihood has no finite candidate values; ",
+      "the pooled variance is zero or non-finite"
+    )
+  }
+
+  selected_row <- which.max(result$log_likelihood)
+  result[, selected := FALSE]
+  result[selected_row, selected := TRUE]
+  result
+}
+
+message("Reading HC spectrum: ", spectrum_file)
+spectrum <- fread(spectrum_file)
+
+missing_columns <- setdiff(required_spectrum_columns, names(spectrum))
+if (length(missing_columns) > 0L) {
+  stop(
+    "HC spectrum is missing required column(s): ",
+    paste(missing_columns, collapse = ", ")
+  )
+}
+
+if (nrow(spectrum) < 4L) {
+  stop(
+    "At least 4 HCs are required to estimate both primary and secondary ",
+    "profile-likelihood elbows; found ",
+    nrow(spectrum)
+  )
+}
+
+expected_index <- seq_len(nrow(spectrum))
+expected_hc <- paste0("HC", expected_index)
+if (!identical(as.integer(spectrum$index), expected_index) ||
+    !identical(as.character(spectrum$HC), expected_hc)) {
+  stop("HC spectrum must contain consecutive HC1..HCn rows in index order")
+}
+
+values <- as.numeric(spectrum$prop_explained)
+if (anyNA(values) || any(!is.finite(values))) {
+  stop("prop_explained contains NA or non-finite values")
+}
+if (any(values <= 0)) {
+  stop("prop_explained values must all be greater than zero")
+}
+if (any(diff(values) > 0)) {
+  stop("prop_explained values must be ordered from largest to smallest")
+}
+
+message("Calculating primary profile likelihood using HC1..HC", length(values))
+primary <- profile_likelihood(
+  values,
+  analysis = "primary_full_spectrum",
+  index_offset = 0L
+)
+
+message("Calculating secondary profile likelihood using HC2..HC", length(values))
+secondary <- profile_likelihood(
+  values[-1L],
+  analysis = "secondary_excluding_HC1",
+  index_offset = 1L
+)
+
+likelihood_results <- rbindlist(list(primary, secondary), use.names = TRUE)
+fwrite(likelihood_results, likelihood_file)
+
+primary_selected <- primary[selected == TRUE]
+secondary_selected <- secondary[selected == TRUE]
+final_cutoff <- as.integer(secondary_selected$cutoff_hc)
+selection_status <- if (secondary_selected$n_noise < minimum_noise_hcs) {
+  "review_required"
+} else {
+  "ok"
+}
+
+selection_summary <- data.table(
+  n_hcs_available = length(values),
+  primary_cutoff = as.integer(primary_selected$cutoff_hc),
+  secondary_local_q = as.integer(secondary_selected$local_q),
+  final_cutoff = final_cutoff,
+  minimum_noise_hcs = minimum_noise_hcs,
+  remaining_noise_hcs = as.integer(secondary_selected$n_noise),
+  input_scale = "raw_prop_explained",
+  status = selection_status
+)
+fwrite(selection_summary, selection_file)
+
+plot_data <- copy(likelihood_results)
+plot_data[, analysis_label := factor(
+  analysis,
+  levels = c("primary_full_spectrum", "secondary_excluding_HC1"),
+  labels = c(
+    "Primary profile likelihood: HC1 onwards",
+    "Secondary profile likelihood: HC1 excluded"
+  )
+)]
+
+selection_lines <- plot_data[selected == TRUE, .(
+  analysis_label,
+  cutoff_hc
+)]
+
+profile_plot <- ggplot(
+  plot_data,
+  aes(x = cutoff_hc, y = log_likelihood)
+) +
+  geom_line(linewidth = 0.5, na.rm = TRUE) +
+  geom_point(size = 1, na.rm = TRUE) +
+  geom_vline(
+    data = selection_lines,
+    aes(xintercept = cutoff_hc),
+    colour = "red",
+    linetype = "dashed",
+    linewidth = 0.6
+  ) +
+  facet_wrap(~analysis_label, ncol = 1, scales = "free_y") +
+  labs(
+    title = "Profile-likelihood selection of Haplotype Components",
+    subtitle = paste0(
+      "Primary cutoff: HC",
+      primary_selected$cutoff_hc,
+      "; final secondary cutoff: HC",
+      final_cutoff
+    ),
+    x = "Cutoff after HC",
+    y = "Profile log-likelihood"
+  ) +
+  theme_bw()
+
+ggsave(
+  filename = plot_file,
+  plot = profile_plot,
+  width = 10,
+  height = 8,
+  dpi = 300
+)
+
+if (selection_status == "review_required") {
+  message(
+    "Profile-likelihood cutoff HC",
+    final_cutoff,
+    " leaves only ",
+    secondary_selected$n_noise,
+    " noise HCs; at least ",
+    minimum_noise_hcs,
+    " are required. Selection requires review, so no selected HC file ",
+    "was written."
+  )
+} else {
+  message("Reading complete HC file: ", complete_hcs_file)
+  complete_hcs <- fread(complete_hcs_file)
+  required_hc_columns <- paste0("HC", seq_len(final_cutoff))
+  required_output_columns <- c("FID", "IID", required_hc_columns)
+  missing_hc_columns <- setdiff(required_output_columns, names(complete_hcs))
+
+  if (length(missing_hc_columns) > 0L) {
+    stop(
+      "Complete HC file is missing required column(s): ",
+      paste(missing_hc_columns, collapse = ", ")
+    )
+  }
+
+  selected_hcs <- complete_hcs[, ..required_output_columns]
+  fwrite(
+    selected_hcs,
+    selected_hcs_file,
+    sep = " ",
+    col.names = TRUE
+  )
+  message(
+    "Selected HC file written with HC1..HC",
+    final_cutoff,
+    ": ",
+    selected_hcs_file
+  )
+}
+
+message("Profile-likelihood results written to: ", likelihood_file)
+message("Profile-likelihood selection written to: ", selection_file)
+message("Profile-likelihood plot written to: ", plot_file)

--- a/resources/parameters
+++ b/resources/parameters
@@ -201,6 +201,10 @@ hcs_file="${home_directory}/processed_data/covariate_data/hcs_file.txt"
 hcs_kernel_prop="${section_01_dir}/hcs_kernel_prop.csv"
 hcs_plot="${section_01_dir}/hcs_kernel.pdf"
 hcs_scatter_plot="${section_01_dir}/hcs_scatter_plot.pdf"
+hcs_profile_selected_file="${home_directory}/processed_data/covariate_data/hcs_profile_selected_file.txt"
+hcs_profile_likelihood="${section_01_dir}/hcs_profile_likelihood.csv"
+hcs_profile_selection="${section_01_dir}/hcs_profile_selection.csv"
+hcs_profile_plot="${section_01_dir}/hcs_profile_likelihood.png"
 
 # phenotype files
 winsorized_pheno="${home_directory}/processed_data/phenotype_data/winsorized_pheno.Robj"
@@ -403,4 +407,3 @@ print_version () {
 	echo ""
 
 }
-


### PR DESCRIPTION
- Keeps full HC output for QC plots and HC-PC comparison
- Uses profile likelihood on HC2 onwards, with HC1 retained
- Writes selected HC file HC1..HCk
- Uses selected HCs in HC-corrected GWAS covariates
- Adds SVD rank fallback when rank 100 fails